### PR TITLE
feat: allow local CSV data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The data for this project is retrieved from Yahoo Finance, focusing on the follo
 
 Features included are Open, High, Low, Close, Adjusted Close, and Volume. Technical indicators such as MACD, RSI, Bollinger Bands, and others are calculated to enhance the dataset.
 
+You can also analyze custom data by supplying a local CSV file. Send a `csvPath` value in the JSON payload to the `/predict` endpoint, and the application will load the dataset from that path instead of downloading it from Yahoo Finance.
+
 ## Setup and Installation
 
 To run this project on your local machine, follow these steps:

--- a/app.py
+++ b/app.py
@@ -251,14 +251,22 @@ def create_dataset(data, target, look_back=1):
 
 @app.route('/predict', methods=["GET", "POST"])
 def predict():
-  data = request.get_json()
-  start_date = data["startDate"]
-  end_date = data["endDate"]
-  stock_name = data["stockName"]
+  payload = request.get_json()
+  start_date = payload["startDate"]
+  end_date = payload["endDate"]
+  stock_name = payload["stockName"]
+  csv_path = payload.get("csvPath")
   print(f"start date {start_date}, end date {end_date} stock name {stock_name}")
   print(f"start date {type(start_date)}, end date {type(end_date)} stock name {type(stock_name)}")
-  yf.pdr_override()
-  data = pdr.get_data_yahoo(stock_name, start=start_date, end=end_date)
+
+  if csv_path:
+    data = pd.read_csv(csv_path, index_col='Date', parse_dates=True)
+    if start_date and end_date:
+      data = data.loc[start_date:end_date]
+  else:
+    yf.pdr_override()
+    data = pdr.get_data_yahoo(stock_name, start=start_date, end=end_date)
+
   last_row = data.iloc[-1]
 
   open_price = last_row['Open']


### PR DESCRIPTION
## Summary
- enable `/predict` to read stock data from a user-specified CSV file via `csvPath`
- document optional `csvPath` usage in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac87dce9308321aedefea0766e1332